### PR TITLE
Bugfix of guess_validator

### DIFF
--- a/en/guess/output_validators/guess_validator/validate.cc
+++ b/en/guess/output_validators/guess_validator/validate.cc
@@ -1,5 +1,6 @@
 #include <utility>
 #include <string>
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <cmath>
@@ -85,13 +86,13 @@ void check_case()
         {
             cout << "lower\n";
             cout.flush();
-            sol_hi = guess-1;
+            sol_hi = min(sol_hi, guess-1);
         }
         else
         {
             cout << "higher\n";
             cout.flush();
-            sol_lo = guess+1;
+            sol_lo = max(sol_lo, guess+1);
         }
     }
     wrong_answer("Didn't get to correct answer in 10 guesses\n");


### PR DESCRIPTION
The interval [sol_lo, sol_hi] should never grow, or it may result in inconsistent response under malformed guessing strategy.
For example:
[1, 1000] -> guess 501 -> response lower ->
[1, 500] -> guess 250 -> response higher ->
[251, 500] -> guess 1000 -> response lower ->
[251, 999] -> guess 501 -> response higher!!!!!!
